### PR TITLE
Terraform list issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
   },
   "dependencies": {
     "aws-sdk": "^2.140.0",
-    "uuid": "^3.1.0",
-    "serverless-dynamodb-client": "0.0.2"
+    "serverless-dynamodb-client": "0.0.2",
+    "uuid": "^3.1.0"
   },
   "jest": {
     "transform": {

--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
   },
   "dependencies": {
     "aws-sdk": "^2.140.0",
-    "serverless-dynamodb-client": "0.0.2",
-    "uuid": "^3.1.0"
+    "uuid": "^3.1.0",
+    "serverless-dynamodb-client": "0.0.2"
   },
   "jest": {
     "transform": {

--- a/src/interfaces/itest-result.ts
+++ b/src/interfaces/itest-result.ts
@@ -4,6 +4,6 @@ import { ICompetency } from "./icompetency";
 export interface ITestResult {
 	id?: string,
 	candidateId: string,
-	faults: ICompetency[]
+	faults: string
 }
 

--- a/src/services/test-result.spec.ts
+++ b/src/services/test-result.spec.ts
@@ -13,7 +13,7 @@ const mockDBWithPutFailure = jest.fn<DynamoDB.DocumentClient>(() => ({
 }))();
 const validTestResult = {
 	candidateId: "some candidate Id",
-	faults: []
+	faults: "[]"
 }
 
 let testResultService: TestResultService;

--- a/src/services/test-result.ts
+++ b/src/services/test-result.ts
@@ -1,93 +1,82 @@
-import { ITestResult } from "../interfaces/itest-result";
-import { Callback } from "aws-lambda";
-import createResponse from "../utils/create-response";
-import { DynamoDB, AWSError } from "aws-sdk";
-import * as UUID from "uuid";
-import { IResponse } from "../interfaces/iresponse";
+import { ITestResult } from '../interfaces/itest-result';
+import { Callback } from 'aws-lambda';
+import createResponse from '../utils/create-response';
+import { DynamoDB, AWSError } from 'aws-sdk';
+import * as UUID from 'uuid'
+import { IResponse } from '../interfaces/iresponse';
 
 export default class TestResultService {
-  constructor(private db: DynamoDB.DocumentClient, private tableName: string) {}
 
-  create(requestBody: any, callback: Callback) {
-    const testResultData: ITestResult = this.extractTestResult(requestBody);
-    const validationErrorResponse = this.validateTestResult(testResultData);
+	constructor(private db: DynamoDB.DocumentClient, private tableName: string) { }
+	
+	create(requestBody: any, callback: Callback) {
+		const testResultData: ITestResult = this.extractTestResult(requestBody);
+		const validationErrorResponse = this.validateTestResult(testResultData);
 
-    if (validationErrorResponse) {
-      return callback(null, validationErrorResponse);
-    }
+		if (validationErrorResponse) {
+			return callback(null, validationErrorResponse)
+		}
 
-    const id = UUID.v1();
-    const params = {
-      TableName: this.tableName,
-      Item: { ...testResultData, id }
-    };
+		const id = UUID.v1()
+		const params = {
+			TableName: this.tableName,
+			Item: { ...testResultData, id }
+		};
 
-    this.db.put(params, (err: AWSError) => {
-      if (err) {
-        const error = createResponse(
-          {
-            message: "Error!",
-            error: err
-          },
-          500
-        );
+		this.db.put(params, (err: AWSError) => {
+			if (err) {
+				const error = createResponse({
+					message: 'Error!',
+					error: err
+				}, 500);
 
-        callback(null, error);
-      } else {
-        const statusCode = 201;
-        const headers = {
-          Location: `/test-result/${id}`,
-          "Access-Control-Expose-Headers": "Location"
-        };
+				callback(null, error);
+			} else {
+				const statusCode = 201;
+				const headers = {
+					'Location': `/test-result/${id}`,
+					'Access-Control-Expose-Headers': 'Location'
+				}
 
-        callback(null, createResponse(null, statusCode, headers));
-      }
-    });
-  }
+				callback(null, createResponse(null, statusCode, headers));
+			}
+		});
+	}
 
-  private validateTestResult(testResultData: ITestResult): IResponse | null {
-    if (
-      !testResultData.candidateId ||
-      typeof testResultData.candidateId !== "string"
-    ) {
-      return this.createMissingPropertyError("candidateId");
-    } else if (
-      !testResultData.faults ||
-      typeof testResultData.faults !== "string"
-    ) {
-      return this.createMissingPropertyError("faults");
-    }
+	private validateTestResult(testResultData: ITestResult): IResponse | null {
+		if (!testResultData.candidateId || typeof (testResultData.candidateId) !== 'string') {
+			return this.createMissingPropertyError('candidateId')
+		} else if (!testResultData.faults || typeof (testResultData.faults) !== 'object') {
+			return this.createMissingPropertyError('faults')
+		}
 
-    return null;
-  }
+		return null;
+	}
 
-  private createMissingPropertyError(propertyName): IResponse {
-    return createResponse(
-      {
-        title: "Error",
-        message: `${propertyName} property is missing`
-      },
-      400
-    );
-  }
+	private createMissingPropertyError(propertyName): IResponse {
+		return createResponse({
+			title: 'Error',
+			message: `${propertyName} property is missing`,
+		}, 400);
+	}
 
-  private extractTestResult(object: any): ITestResult {
-    let body: any;
+	private extractTestResult(object: any): ITestResult {
+		let body: any;
 
-    if (object && typeof object === "object") {
-      body = object;
-    } else {
-      try {
-        body = JSON.parse(object);
-      } catch (e) {
-        console.error(`Couldn\'t parse body ${e}`);
-      }
-    }
+		if (object && typeof (object) === 'object') {
+			body = object
+		} else {
+			try {
+				body = JSON.parse(object);
+			} catch (e) {
+				console.error(`Couldn\'t parse body ${e}`)
+			}
+		}
 
-    const { candidateId, faults } = body;
-    return {
-      candidateId,
-      faults
-    };
-  }
+		const { candidateId, faults } = body;
+		return {
+			candidateId,
+			faults
+		}
+	}
 }

--- a/src/services/test-result.ts
+++ b/src/services/test-result.ts
@@ -12,7 +12,7 @@ export default class TestResultService {
 	create(requestBody: any, callback: Callback) {
 		const testResultData: ITestResult = this.extractTestResult(requestBody);
 		const validationErrorResponse = this.validateTestResult(testResultData);
-
+		
 		if (validationErrorResponse) {
 			return callback(null, validationErrorResponse)
 		}
@@ -22,6 +22,8 @@ export default class TestResultService {
 			TableName: this.tableName,
 			Item: { ...testResultData, id }
 		};
+		
+		console.log(params);
 
 		this.db.put(params, (err: AWSError) => {
 			if (err) {
@@ -46,7 +48,7 @@ export default class TestResultService {
 	private validateTestResult(testResultData: ITestResult): IResponse | null {
 		if (!testResultData.candidateId || typeof (testResultData.candidateId) !== 'string') {
 			return this.createMissingPropertyError('candidateId')
-		} else if (!testResultData.faults || typeof (testResultData.faults) !== 'object') {
+		} else if (!testResultData.faults || typeof (testResultData.faults) !== 'string') {
 			return this.createMissingPropertyError('faults')
 		}
 
@@ -68,7 +70,7 @@ export default class TestResultService {
 		} else {
 			try {
 				body = JSON.parse(object);
-				body.faults = JSON.parse(body.faults)
+				// body.faults = JSON.parse(body.faults)
 			} catch (e) {
 				console.error(`Couldn\'t parse body ${e}`)
 			}

--- a/src/services/test-result.ts
+++ b/src/services/test-result.ts
@@ -46,7 +46,7 @@ export default class TestResultService {
 	private validateTestResult(testResultData: ITestResult): IResponse | null {
 		if (!testResultData.candidateId || typeof (testResultData.candidateId) !== 'string') {
 			return this.createMissingPropertyError('candidateId')
-		} else if (!testResultData.faults || typeof (testResultData.faults) !== 'object') {
+		} else if (!testResultData.faults || typeof (testResultData.faults) !== 'string') {
 			return this.createMissingPropertyError('faults')
 		}
 

--- a/src/services/test-result.ts
+++ b/src/services/test-result.ts
@@ -1,85 +1,93 @@
-import { ITestResult } from '../interfaces/itest-result';
-import { Callback } from 'aws-lambda';
-import createResponse from '../utils/create-response';
-import { DynamoDB, AWSError } from 'aws-sdk';
-import * as UUID from 'uuid'
-import { IResponse } from '../interfaces/iresponse';
+import { ITestResult } from "../interfaces/itest-result";
+import { Callback } from "aws-lambda";
+import createResponse from "../utils/create-response";
+import { DynamoDB, AWSError } from "aws-sdk";
+import * as UUID from "uuid";
+import { IResponse } from "../interfaces/iresponse";
 
 export default class TestResultService {
+  constructor(private db: DynamoDB.DocumentClient, private tableName: string) {}
 
-	constructor(private db: DynamoDB.DocumentClient, private tableName: string) { }
-	
-	create(requestBody: any, callback: Callback) {
-		const testResultData: ITestResult = this.extractTestResult(requestBody);
-		const validationErrorResponse = this.validateTestResult(testResultData);
-		
-		if (validationErrorResponse) {
-			return callback(null, validationErrorResponse)
-		}
+  create(requestBody: any, callback: Callback) {
+    const testResultData: ITestResult = this.extractTestResult(requestBody);
+    const validationErrorResponse = this.validateTestResult(testResultData);
 
-		const id = UUID.v1()
-		const params = {
-			TableName: this.tableName,
-			Item: { ...testResultData, id }
-		};
-		
-		console.log(params);
+    if (validationErrorResponse) {
+      return callback(null, validationErrorResponse);
+    }
 
-		this.db.put(params, (err: AWSError) => {
-			if (err) {
-				const error = createResponse({
-					message: 'Error!',
-					error: err
-				}, 500);
+    const id = UUID.v1();
+    const params = {
+      TableName: this.tableName,
+      Item: { ...testResultData, id }
+    };
 
-				callback(null, error);
-			} else {
-				const statusCode = 201;
-				const headers = {
-					'Location': `/test-result/${id}`,
-					'Access-Control-Expose-Headers': 'Location'
-				}
+    this.db.put(params, (err: AWSError) => {
+      if (err) {
+        const error = createResponse(
+          {
+            message: "Error!",
+            error: err
+          },
+          500
+        );
 
-				callback(null, createResponse(null, statusCode, headers));
-			}
-		});
-	}
+        callback(null, error);
+      } else {
+        const statusCode = 201;
+        const headers = {
+          Location: `/test-result/${id}`,
+          "Access-Control-Expose-Headers": "Location"
+        };
 
-	private validateTestResult(testResultData: ITestResult): IResponse | null {
-		if (!testResultData.candidateId || typeof (testResultData.candidateId) !== 'string') {
-			return this.createMissingPropertyError('candidateId')
-		} else if (!testResultData.faults || typeof (testResultData.faults) !== 'string') {
-			return this.createMissingPropertyError('faults')
-		}
+        callback(null, createResponse(null, statusCode, headers));
+      }
+    });
+  }
 
-		return null;
-	}
+  private validateTestResult(testResultData: ITestResult): IResponse | null {
+    if (
+      !testResultData.candidateId ||
+      typeof testResultData.candidateId !== "string"
+    ) {
+      return this.createMissingPropertyError("candidateId");
+    } else if (
+      !testResultData.faults ||
+      typeof testResultData.faults !== "string"
+    ) {
+      return this.createMissingPropertyError("faults");
+    }
 
-	private createMissingPropertyError(propertyName): IResponse {
-		return createResponse({
-			title: 'Error',
-			message: `${propertyName} property is missing`,
-		}, 400);
-	}
+    return null;
+  }
 
-	private extractTestResult(object: any): ITestResult {
-		let body: any;
-		
-		if (object && typeof (object) === 'object') {
-			body = object
-		} else {
-			try {
-				body = JSON.parse(object);
-				// body.faults = JSON.parse(body.faults)
-			} catch (e) {
-				console.error(`Couldn\'t parse body ${e}`)
-			}
-		}
+  private createMissingPropertyError(propertyName): IResponse {
+    return createResponse(
+      {
+        title: "Error",
+        message: `${propertyName} property is missing`
+      },
+      400
+    );
+  }
 
-		const { candidateId, faults } = body;
-		return {
-			candidateId,
-			faults
-		}
-	}
+  private extractTestResult(object: any): ITestResult {
+    let body: any;
+
+    if (object && typeof object === "object") {
+      body = object;
+    } else {
+      try {
+        body = JSON.parse(object);
+      } catch (e) {
+        console.error(`Couldn\'t parse body ${e}`);
+      }
+    }
+
+    const { candidateId, faults } = body;
+    return {
+      candidateId,
+      faults
+    };
+  }
 }

--- a/src/services/test-result.ts
+++ b/src/services/test-result.ts
@@ -62,12 +62,13 @@ export default class TestResultService {
 
 	private extractTestResult(object: any): ITestResult {
 		let body: any;
-
+		
 		if (object && typeof (object) === 'object') {
 			body = object
 		} else {
 			try {
 				body = JSON.parse(object);
+				body.faults = JSON.parse(body.faults)
 			} catch (e) {
 				console.error(`Couldn\'t parse body ${e}`)
 			}


### PR DESCRIPTION
Syzmon was having the following issue when sending a request to this microservice.

```
curl -X POST  -H "Content-Type: application/json" -d '{"candidateId": "someCandidateId","faults":[{"id":"juncSpeed","faultsNo":10,"isSerious":false,"isDangerous":false}]}' https://ops.nonprod.mes.dvsacloud.uk/alpha/test-result/
{"message":"Error!","error":{"message":"One or more parameter values were invalid: Type mismatch for Index Key faults Expected: S Actual: L IndexName: faultsIndex","code":"ValidationException","time":"2018-04-19T13:16:19.026Z","requestId":"TUASO0K5DQB5AB2PKIFQ3MLUCRVV4KQNSO5AEMVJF66Q9ASUAAJG","statusCode":400,"retryable":false,"retryDelay":45.326034416910346}}%
```

DynamoDB did not like the faults array type that was being stored so to resolve this issue I have altered the micro service to store a serialised string of the faults array instead. 

Example request below should work :

```
curl -X POST -H "Content-Type: application/json" -d '{"candidateId": "someCandidateId","faults":	"[{\"id\":\"juncSpeed\",\"faultsNo\":10,\"isSerious\":false,\"isDangerous\":false}]"}'
https://ops.nonprod.mes.dvsacloud.uk/alpha/test-result/
```